### PR TITLE
Update Copyright text and description.

### DIFF
--- a/src/components/FaucetForm/FaucetForm.module.scss
+++ b/src/components/FaucetForm/FaucetForm.module.scss
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/FaucetForm/faucetForm.js
+++ b/src/components/FaucetForm/faucetForm.js
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/components/Footer/footer.js
+++ b/src/components/Footer/footer.js
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pages/api/claim.js
+++ b/src/pages/api/claim.js
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -147,7 +147,7 @@ const Home = function ({ serverError, faucetAccount }) {
 								Thirsty? Take a drink.
 								{' '}
 								<br />
-								This faucet is running on the Symbol testnet and dispenses up to 10,000 XEM per account.
+								This faucet is running on the NEM testnet and dispenses up to 10,000 XEM per account.
 							</p>
 						</div>
 
@@ -161,7 +161,7 @@ const Home = function ({ serverError, faucetAccount }) {
 						<p>Done with your XEM? Send it back to the faucet. Remember, sharing is caring!</p>
 
 						<p>
-							If you’re looking to set up a voting node on Symbol (minimum 3,000,000 XEM), please send a request to
+							If you have more questions, please send a request to
 							<a target="_blank" href="https://t.me/nemhelpdesk" rel="noreferrer"> @nemhelpdesk</a>
 							{' '}
 							on Telegram, or

--- a/src/services/fetch.js
+++ b/src/services/fetch.js
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/services/nemRequest.js
+++ b/src/services/nemRequest.js
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,5 +1,5 @@
 /*
- * (C) Symbol Contributors 2021
+ * (C) NEM Contributors 2022
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What was the issue?
- The copyright text was incorrect, and some description on the main page was not right.

## What's the fix?
- Update copyright text from `Symbol Contributors 2021` -> `NEM Contributors 2022`
- Replace words to 'Symbol' -> 'Nem'
- Replace `set up a voting node on Symbol` -> `If you have more questions`